### PR TITLE
Change the default context to an empty object instead of the window

### DIFF
--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -306,7 +306,7 @@ export class Tmplits {
     //context is the context to load the page with
     loadPage(containerId, pageName, context) {
         var template = this.get(pageName);
-        context = context ? context : window                    
+        context = context ? context : {}                    
         log(`Loading page: ${pageName}`)
         let dom = containerId
         try{


### PR DESCRIPTION
When someone pushes a partial with tmplit, it was adding the window as the context. This solved a problem at some point, but i don't think its a good fix. 

Since I'm not sure what problem it solved, and because it causes other issues, i'm gonna do this, then fix something later if it comes up again.