### PR TITLE
Implement more use cases for page select

### DIFF
--- a/example/HMI/app/views/main.handlebars
+++ b/example/HMI/app/views/main.handlebars
@@ -16,7 +16,7 @@ class='webhmi-hide'
 {{> 'icon'
 img="app/assets/wireframe.png"
 data-var-name='tmplitTest:tmplit.SetButton'
-    class='webhmi-btn-set webhmi-hide'
+class='webhmi-btn-set webhmi-hide'
 }}
 
 
@@ -155,15 +155,22 @@ don't worry about this one could be broken -->
 
 <div>
     Multi Page Select
-    {{#tmplit 'MultiSelect' maxColumns=10 data-var-name="tmplitTest:tmplit.MultiSelect_INT" data-var-name-field="tmplitTest:tmplit.MultiSelect_STRING"}}
+    {{#tmplit 'MultiSelect' maxColumns=11 data-var-name="tmplitTest:tmplit.MultiSelect_INT" data-var-name-field="tmplitTest:tmplit.MultiSelect_STRING"}}
     <options>
-        {{tmplit 'PageSelect' 'Page 1: json' ctx='{"msg":"hello"}' dom="container1" template="page1"}}
-        {{tmplit 'PageSelect' 'Page 2: javascript' ctx='this.innerHTML' dom="container1" template="page2"}}
-        {{tmplit 'PageSelect' 'Page 3: string' ctx='Hello' dom="container1" template="page2"}}
-        {{tmplit 'PageSelect' 'Page 4: function' ctx='()=>{return "Answer: " + (3.0 +2.0) }' dom="container1" template="page2"}}
-        {{tmplit 'PageSelect' 'Page 5: number' ctx=3 dom="container1" template="page2"}}
-        {{tmplit 'PageSelect' 'Page 6: object' ctx=(obj '{"msg":"hello"}') dom="container1" template="page1"}}
-        {{tmplit 'PageSelect' 'Page 7: none' dom="container1" template="page2"}}
+        {{tmplit 'PageSelect' 'Empty' ctx='{"msg":"hello"}' dom="container1" template="page1" }}
+        {{#tmplit 'PageSelect' ctx='{"msg":"hello"}' dom="container1" template="page1"}}
+        Supply Text
+        {{/tmplit}}
+        {{#tmplit 'PageSelect' ctx='{"msg":"hello"}' test=1 dom="container1" template="page1"}}
+        <div data="1">test</div>
+        {{/tmplit}}
+        {{tmplit 'PageSelectDiv' 'Page 1: json' ctx='{"msg":"hello"}' dom="container1" template="page1" }}
+        {{tmplit 'PageSelectNav' 'Page 2: javascript' ctx='this.innerHTML' dom="container1" template="page2"}}
+        {{tmplit 'PageSelectNav' 'Page 3: string' ctx='Hello' dom="container1" template="page2"}}
+        {{tmplit 'PageSelectNav' 'Page 4: function' ctx='()=>{return "Answer: " + (3.0 +2.0) }' dom="container1" template="page2"}}
+        {{tmplit 'PageSelectNav' 'Page 5: number' ctx=3 dom="container1" template="page2"}}
+        {{tmplit 'PageSelectNav' 'Page 6: object' ctx=(obj '{"msg":"hello"}') dom="container1" template="page1"}}
+        {{tmplit 'PageSelectNav' 'Page 7: none' dom="container1" template="page2"}}
     </options>
     {{/tmplit}}
 </div>
@@ -188,6 +195,11 @@ don't worry about this -->
 {{tmplit 'PageSelect' 'Page 5: number' ctx=3 dom="container1" template="page2"}}
 {{tmplit 'PageSelect' 'Page 6: object' ctx=(obj '{"msg":"hello"}') dom="container1" template="page1"}}
 {{tmplit 'PageSelect' 'Page 7: none' dom="container1" template="page2"}}
+{{#tmplit 'PageSelect' ctx='{"msg":"hello"}' dom="container1" template="page1" active=true}}
+test Empty Text Before
+<div data-value="1">Div</div>
+test Empty Text After
+{{/tmplit}}
 
 <script id="page1" type="text/x-handlebars-template">
 <!-- write your page 2 with normal html -->

--- a/example/HMI/package-lock.json
+++ b/example/HMI/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "template-test-hmi",
   "version": "0.0.25",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -40,17 +40,73 @@
     },
     "../../src/HMI": {
       "name": "@loupeteam/tmplits",
-      "version": "0.0.8",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "0.0.10",
+      "license": "MIT",
       "dependencies": {
         "handlebars": "*",
         "jquery": "*"
       }
     },
+    "../../src/HMI/node_modules/handlebars": {
+      "version": "4.7.8",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "../../src/HMI/node_modules/jquery": {
+      "version": "3.7.1",
+      "license": "MIT"
+    },
+    "../../src/HMI/node_modules/minimist": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../src/HMI/node_modules/neo-async": {
+      "version": "2.6.2",
+      "license": "MIT"
+    },
+    "../../src/HMI/node_modules/source-map": {
+      "version": "0.6.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../src/HMI/node_modules/uglify-js": {
+      "version": "3.17.4",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "../../src/HMI/node_modules/wordwrap": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
     "../../src/tmplits/tmplits-button": {
       "name": "@loupeteam/tmplits-button",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -58,8 +114,8 @@
     },
     "../../src/tmplits/tmplits-checkbox": {
       "name": "@loupeteam/tmplits-checkbox",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -67,8 +123,8 @@
     },
     "../../src/tmplits/tmplits-columns": {
       "name": "@loupeteam/tmplits-columns",
-      "version": "0.0.3",
-      "license": "ISC",
+      "version": "0.0.5",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -76,8 +132,8 @@
     },
     "../../src/tmplits/tmplits-columnsbs": {
       "name": "@loupeteam/tmplits-columnsbs",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -85,8 +141,8 @@
     },
     "../../src/tmplits/tmplits-directorybrowser": {
       "name": "@loupeteam/tmplits-directorybrowser",
-      "version": "0.0.2",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -94,8 +150,8 @@
     },
     "../../src/tmplits/tmplits-directorybrowserwindow": {
       "name": "@loupeteam/tmplits-directorybrowserwindow",
-      "version": "0.0.2",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -103,8 +159,8 @@
     },
     "../../src/tmplits/tmplits-dropdown": {
       "name": "@loupeteam/tmplits-dropdown",
-      "version": "0.0.2",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -112,8 +168,8 @@
     },
     "../../src/tmplits/tmplits-dropdowntable": {
       "name": "@loupeteam/tmplits-dropdowntable",
-      "version": "0.0.2",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -121,13 +177,13 @@
     },
     "../../src/tmplits/tmplits-globalclasses": {
       "name": "@loupeteam/tmplits-globalclasses",
-      "version": "0.0.3",
-      "license": "ISC"
+      "version": "0.0.5",
+      "license": "MIT"
     },
     "../../src/tmplits/tmplits-labeledlist": {
       "name": "@loupeteam/tmplits-labeledlist",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -135,8 +191,8 @@
     },
     "../../src/tmplits/tmplits-led": {
       "name": "@loupeteam/tmplits-led",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -144,8 +200,8 @@
     },
     "../../src/tmplits/tmplits-multiselect": {
       "name": "@loupeteam/tmplits-multiselect",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -153,8 +209,8 @@
     },
     "../../src/tmplits/tmplits-numeric": {
       "name": "@loupeteam/tmplits-numeric",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.5",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -162,8 +218,8 @@
     },
     "../../src/tmplits/tmplits-numgrid": {
       "name": "@loupeteam/tmplits-numgrid",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -171,8 +227,8 @@
     },
     "../../src/tmplits/tmplits-page": {
       "name": "@loupeteam/tmplits-page",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -180,8 +236,8 @@
     },
     "../../src/tmplits/tmplits-pageselect": {
       "name": "@loupeteam/tmplits-pageselect",
-      "version": "0.0.2",
-      "license": "ISC",
+      "version": "0.0.5",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -189,8 +245,8 @@
     },
     "../../src/tmplits/tmplits-slider": {
       "name": "@loupeteam/tmplits-slider",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -198,8 +254,8 @@
     },
     "../../src/tmplits/tmplits-tableselect": {
       "name": "@loupeteam/tmplits-tableselect",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -207,8 +263,8 @@
     },
     "../../src/tmplits/tmplits-text": {
       "name": "@loupeteam/tmplits-text",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -216,13 +272,13 @@
     },
     "../../src/tmplits/tmplits-utilities": {
       "name": "@loupeteam/tmplits-utilities",
-      "version": "0.0.2",
-      "license": "ISC"
+      "version": "0.0.4",
+      "license": "MIT"
     },
     "../../src/tmplits/tmplits-valueupdown": {
       "name": "@loupeteam/tmplits-valueupdown",
-      "version": "0.0.1",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@loupeteam/tmplits-globalclasses": "*",
         "@loupeteam/tmplits-utilities": "*"
@@ -319,8 +375,6 @@
     },
     "node_modules/@loupeteam/webhmi": {
       "version": "1.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@loupeteam/webhmi/1.5.1/6dcb40bfbc705cd90b0d927f2af41dd644fa7dd4",
-      "integrity": "sha512-5XvFPc4lcjXyXyq38CKFPxddtOxHC6sxhRPiP5a3cwlMchv0XVEttZ7LugWWhZRUCfHkH18fa3XNX+kW9oXRuQ==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/app": {
@@ -329,16 +383,14 @@
     },
     "node_modules/bootstrap": {
       "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -357,34 +409,29 @@
     },
     "node_modules/jquery": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
+      "license": "MIT"
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -395,215 +442,7 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
-    },
-    "public": {
-      "extraneous": true
-    }
-  },
-  "dependencies": {
-    "@loupeteam/tmplits": {
-      "version": "file:../../src/HMI",
-      "requires": {
-        "handlebars": "*",
-        "jquery": "*"
-      }
-    },
-    "@loupeteam/tmplits-button": {
-      "version": "file:../../src/tmplits/tmplits-button",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-checkbox": {
-      "version": "file:../../src/tmplits/tmplits-checkbox",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-columns": {
-      "version": "file:../../src/tmplits/tmplits-columns",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-columnsbs": {
-      "version": "file:../../src/tmplits/tmplits-columnsbs",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-directorybrowser": {
-      "version": "file:../../src/tmplits/tmplits-directorybrowser",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-directorybrowserwindow": {
-      "version": "file:../../src/tmplits/tmplits-directorybrowserwindow",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-dropdown": {
-      "version": "file:../../src/tmplits/tmplits-dropdown",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-dropdowntable": {
-      "version": "file:../../src/tmplits/tmplits-dropdowntable",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-globalclasses": {
-      "version": "file:../../src/tmplits/tmplits-globalclasses"
-    },
-    "@loupeteam/tmplits-labeledlist": {
-      "version": "file:../../src/tmplits/tmplits-labeledlist",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-led": {
-      "version": "file:../../src/tmplits/tmplits-led",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-multiselect": {
-      "version": "file:../../src/tmplits/tmplits-multiselect",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-numeric": {
-      "version": "file:../../src/tmplits/tmplits-numeric",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-numgrid": {
-      "version": "file:../../src/tmplits/tmplits-numgrid",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-page": {
-      "version": "file:../../src/tmplits/tmplits-page",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-pageselect": {
-      "version": "file:../../src/tmplits/tmplits-pageselect",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-slider": {
-      "version": "file:../../src/tmplits/tmplits-slider",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-tableselect": {
-      "version": "file:../../src/tmplits/tmplits-tableselect",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-text": {
-      "version": "file:../../src/tmplits/tmplits-text",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/tmplits-utilities": {
-      "version": "file:../../src/tmplits/tmplits-utilities"
-    },
-    "@loupeteam/tmplits-valueupdown": {
-      "version": "file:../../src/tmplits/tmplits-valueupdown",
-      "requires": {
-        "@loupeteam/tmplits-globalclasses": "*",
-        "@loupeteam/tmplits-utilities": "*"
-      }
-    },
-    "@loupeteam/webhmi": {
-      "version": "1.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@loupeteam/webhmi/1.5.1/6dcb40bfbc705cd90b0d927f2af41dd644fa7dd4",
-      "integrity": "sha512-5XvFPc4lcjXyXyq38CKFPxddtOxHC6sxhRPiP5a3cwlMchv0XVEttZ7LugWWhZRUCfHkH18fa3XNX+kW9oXRuQ=="
-    },
-    "app": {
-      "version": "file:app"
-    },
-    "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
-    },
-    "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
-    "jquery": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "license": "MIT"
     }
   }
 }

--- a/src/tmplits/tmplits-pageselect/module.js
+++ b/src/tmplits/tmplits-pageselect/module.js
@@ -27,12 +27,75 @@ page2
 
 import * as util from "../tmplits-utilities/module.js"
 
+//Page select will decide which page to show based on what the user supplies for children
 export function TmplitPageSelect(context, args) {
+
+    //Get children if they exist
+    let children = args.children
+
+    //If the user provides children, use them and do the minimal amount of processing
+    if (children.length > 0) {
+        let {
+            active,
+            template,
+            dom,
+            ctx,
+            ..._args
+        } = args.hash
+        //Get cleaned values
+        let {
+            attr
+        } = util.cleanArgs(_args)
+
+        attr = util.appendContextToAttr(attr, ctx)
+        let nodes = util.htmlToElements(args.children)
+        let children = ''
+        if (nodes.length == 1 && nodes[0].tagName == undefined) {
+            //If the user only provides text, use the div version
+            return TmplitPageSelectDiv([nodes[0].textContent], args)
+        }
+        else {
+            //If the user provides html, add the data attributes to the html and return it
+            for (let i = 0; i < nodes.length; i++) {
+                let el = nodes[i]
+                switch (el.tagName) {
+                    case undefined:
+                        children += el.textContent
+                        break
+                    default:
+                        el.setAttribute('data-page', template)
+                        el.setAttribute('data-target-dom', dom)
+                        if (active) {
+                            el.classList.add('active')
+                        }
+                        //Go through the _args and add them to the element
+                        Object.keys(_args).map((v) => {
+                            el.setAttribute(v, _args[v])
+                        })
+                        //If ctx is provided, append it to the attr
+                        if (ctx) {
+                            el.setAttribute('data-context', ctx)
+                        }
+                        children += el.outerHTML
+                }
+            }
+        }
+        return children
+    }
+    //If the user doesn't provide children, fallback to the original behavior
+    else {
+        return TmplitPageSelectNav(context, args)
+    }
+}
+
+//Page select to use in a nav tab
+export function TmplitPageSelectNav(context, args) {
     let {
         active,
         template,
         dom,
         ctx,
+        ["data-value"]: data_value,
         ..._args
     } = args.hash
     //Get cleaned values
@@ -46,10 +109,33 @@ export function TmplitPageSelect(context, args) {
     }
 
     attr = util.appendContextToAttr(attr, ctx)
-
     return `
-<li class="${classList.join(' ')}" >
+<li class="${classList.join(' ')}" ${typeof data_value != 'undefined' ? `data-value=${data_value}` : ''} >
     <a data-page='${template}' data-target-dom='${dom}' ${attr}>${context[0]}</a>
 </li>
 `
+}
+
+//Minimal page select to use in a div
+export function TmplitPageSelectDiv(context, args) {
+    let {
+        active,
+        template,
+        dom,
+        ctx,
+        ..._args
+    } = args.hash
+    //Get cleaned values
+    let {
+        classList,
+        attr
+    } = util.cleanArgs(_args)
+
+    if (active) {
+        classList = classList.concat(['active'])
+    }
+
+    attr = util.appendContextToAttr(attr, ctx)
+
+    return `<div class="${classList.join(' ')}" data-page='${template}' data-target-dom='${dom}' ${attr}>${context[0]}</div>`
 }

--- a/src/tmplits/tmplits-pageselect/package.json
+++ b/src/tmplits/tmplits-pageselect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits-pageselect",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR creates new tmplits for page select that aren't the default li a used inside a nav.

It also changes the current tmplit to a smarter one to decide which to used based on what the user supplies. By default, the behavior of old applications should be the same.