### PR TITLE
Fix jQuery Conflict prelux

### DIFF
--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -11,14 +11,20 @@ import "../../jquery/dist/jquery.js"
 import * as util from "../tmplits-utilities/module.js"
 
 //Check if jquery has already been loaded
-//If it hasn't then load it
-if( !window.$ ){
-    window.$ = jQuery
+//If it hasn't then save it to the window for others to use
+if (!window.$) {
+    window.$ = jQueryImport
     console.error('Loading JQuery in tmplits.js. To avoid this ensure that JQuery is loaded before tmplits.js')
 }
-let log = function( t ){ if(Tmplits.debug.loglevel == 0){ console.log(t) }};
-let warn = function( t ){ if(Tmplits.debug.loglevel <= 1){ console.warn(t) }};
-let error = function( t ){ if(Tmplits.debug.loglevel <= 2){ console.error(t) }};
+else {
+    //Use deep no conflict to avoid conflicts with other loading JQuery.
+    // We actually don't care what version of jquery, but we do care if it is loaded
+    // and import requires loading it unconditionally. So we load it here and then
+    // use noConflict to avoid conflicts with other versions of jquery
+    debugger
+    $.noConflict(true);
+}
+
 
 export class Tmplits {
     constructor(node_module_directory, loadedCallback ) {

--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -10,25 +10,23 @@
 import "../../jquery/dist/jquery.js"
 import * as util from "../tmplits-utilities/module.js"
 
-//Check if jquery has already been loaded
-//If it hasn't then save it to the window for others to use
-if (!window.$) {
-    window.$ = jQueryImport
-    console.error('Loading JQuery in tmplits.js. To avoid this ensure that JQuery is loaded before tmplits.js')
-}
-else {
-    //Use deep no conflict to avoid conflicts with other loading JQuery.
-    // We actually don't care what version of jquery, but we do care if it is loaded
-    // and import requires loading it unconditionally. So we load it here and then
-    // use noConflict to avoid conflicts with other versions of jquery
-    debugger
+//There is no way to load jquery as a module, so it will always be loaded as a global
+//If jquery was loaded it means that we are in a browser, or it was already loaded
+//  fall back to any previous version that was loaded. If we are the first version, that is fine too..
+if (window.$) {
     $.noConflict(true);
+}
+//If jquery was not loaded then we are in electron, lets require it
+else {
+    //We don't need no conflict because we already know that jquery is not loaded previously
+    let jqueryImport = require("jquery");
+    window.$ = window.jQuery = jqueryImport;
 }
 
 
 export class Tmplits {
-    constructor(node_module_directory, loadedCallback ) {
-        
+    constructor(node_module_directory, loadedCallback) {
+
         //Get any base element from the page
         this.base = node_module_directory
 
@@ -38,18 +36,18 @@ export class Tmplits {
         this.combinedScript = ''
         this.retryScripts = []
         Tmplits.modules["tmplitsystem"] = true;
-        if(loadedCallback){
-            Tmplits.loadedCallback.push(()=>{loadedCallback(this.native)})
-        }        
-        Tmplits.loadedCallback.push(()=>{this.refreshDynamicDom()})
+        if (loadedCallback) {
+            Tmplits.loadedCallback.push(() => { loadedCallback(this.native) })
+        }
+        Tmplits.loadedCallback.push(() => { this.refreshDynamicDom() })
         this.loadPackageLockJson(this.base + '../package-lock.json')
-        .then(()=>{return this.loadPackageJson(this.base + '../package.json')})
-        .then(()=>{return this.loadJson(this.base + '../tmplits.json')})
-        .then(()=>{return this.getLibraries(this.libraries)})
-        .then(()=>{return this.getPages(this.pages)})
-        .then(()=>{return this.retries()})
-        .then(()=>{return this.addDomListeners()})
-        .then(()=>{return Tmplits.moduleLoaded('tmplitsystem')})        
+            .then(() => { return this.loadPackageJson(this.base + '../package.json') })
+            .then(() => { return this.loadJson(this.base + '../tmplits.json') })
+            .then(() => { return this.getLibraries(this.libraries) })
+            .then(() => { return this.getPages(this.pages) })
+            .then(() => { return this.retries() })
+            .then(() => { return this.addDomListeners() })
+            .then(() => { return Tmplits.moduleLoaded('tmplitsystem') })
     }
     static debug = {
         enabled: true,
@@ -83,27 +81,27 @@ export class Tmplits {
     }
 
     //This function loads a script into the window
-    importScript(script){
+    importScript(script) {
         const encodedJs = encodeURIComponent(script);
         const dataUri = 'data:text/javascript;charset=utf-8,' + encodedJs;
-        try{
+        try {
             import(dataUri).then(ns => {
                 log(`imported ${id} successfully`);
                 Object.assign(window, ns);
-            }).catch(()=>{
+            }).catch(() => {
                 warn(`import failed ${id}, will retry..`)
             })
         }
-        catch(e){
+        catch (e) {
             warn(`import failed ${el.id}, will retry..`)
-        }                  
+        }
     }
 
     //This function reads the libraries and adds each item with the type='text/x-handlebars-template'
     //to the cache
     //it also adds the scripts to the combinedScript
     readLibraries(raw) {
-        log('processing libraries' )
+        log('processing libraries')
         let scope = this
         let html = $.parseHTML(raw)
         if (html) {
@@ -112,28 +110,28 @@ export class Tmplits {
 
                     Handlebars.registerPartial(
                         el.id,
-                        (Tmplits.debug.comment ? `<!--⌄{> ${el.id}}-->${el.text}<!--^{>${el.id}}-->` : el.text )
+                        (Tmplits.debug.comment ? `<!--⌄{> ${el.id}}-->${el.text}<!--^{>${el.id}}-->` : el.text)
                     )
                     scope.cache[el.id] = el.text;
                 }
-                if (el.type == "text/x-handlebars-onload") {          
+                if (el.type == "text/x-handlebars-onload") {
                     scope.combinedScript += el.innerHTML + '\n'
                     log(`loading script ${el.id}`);
                     const encodedJs = encodeURIComponent(el.innerHTML);
                     const dataUri = 'data:text/javascript;charset=utf-8,' + encodedJs;
-                    try{
+                    try {
                         import(dataUri).then(ns => {
                             log(`imported ${el.id} successfully`);
                             Object.assign(window, ns);
-                        }).catch(()=>{
+                        }).catch(() => {
                             warn(`import failed ${el.id}, will retry..`)
-                            scope.retryScripts.push(el)                        
+                            scope.retryScripts.push(el)
                         })
                     }
-                    catch(e){
-                        scope.retryScripts.push(el)                        
+                    catch (e) {
+                        scope.retryScripts.push(el)
                         warn(`import failed ${el.id}, will retry..`)
-                    }                                      
+                    }
                 }
             });
         }
@@ -145,10 +143,10 @@ export class Tmplits {
     getLibraries(libraries) {
 
         let scope = this
-        let chain = new Promise((resolve, reject)=>{          
+        let chain = new Promise((resolve, reject) => {
             log('loading libraries')
             let libraryCount = 0;
-            if(libraries.length == 0){
+            if (libraries.length == 0) {
                 next()
             }
             function next() {
@@ -164,8 +162,8 @@ export class Tmplits {
                         next()
                     })
                     .catch(error => {
-                        warn( 'error loading library ' + error )
-                        next()                    
+                        warn('error loading library ' + error)
+                        next()
                     })
             }
 
@@ -173,7 +171,7 @@ export class Tmplits {
                 fetch(element.file)
                     .then(processPartial)
                     .catch(error => {
-                        warn( 'error loading library ' + error )
+                        warn('error loading library ' + error)
                         next()
                     });
             });
@@ -185,19 +183,19 @@ export class Tmplits {
     //This function loads all the template pages that were found
     //it resolves the pages then processes them by compiling them
     //and adding them to the cache
-    getPages( pagesObj ) {        
+    getPages(pagesObj) {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{          
+        let chain = new Promise((resolve, reject) => {
             log('loading pages')
             let pageCount = 0;
 
             //go through pages object members and add each to an array of pages
             let pages = []
-            for( let page in pagesObj ){
-                pages.push( pagesObj[page] )
+            for (let page in pagesObj) {
+                pages.push(pagesObj[page])
             }
 
-            if(pages.length == 0){
+            if (pages.length == 0) {
                 next()
             }
 
@@ -213,54 +211,54 @@ export class Tmplits {
                 scope.cache[element.name] = partial;
                 Handlebars.registerPartial(
                     element.name,
-                    (Tmplits.debug.comment ? `<!--⌄{> ${element.name}} (${element.file})-->${partial}<!--^{${element.name}}-->` : `${partial}` )
-                    
+                    (Tmplits.debug.comment ? `<!--⌄{> ${element.name}} (${element.file})-->${partial}<!--^{${element.name}}-->` : `${partial}`)
+
                 )
                 next()
             }
 
             pages.forEach(element => {
-                if(element.script){
-                    $.getScript(element.script, function() {
+                if (element.script) {
+                    $.getScript(element.script, function () {
                         log(`loaded script ${element.script}`);
-                    }).catch((e)=>{
+                    }).catch((e) => {
                     });
                 }
             });
 
             pages.forEach(element => {
-                if(element.module){
+                if (element.module) {
                     scope.loadModule(element.module)
                 }
-            });  
+            });
 
             pages.forEach(element => {
                 fetch(element.file)
-                .then((data)=>{
-                    if(data.status != 200 && data.status != 0){
-                    }
-                    else{
-                        return data.text()                        
-                    }
-                })
-                .then((partial) => {
-                    processPartial(element, partial)
-                })
-                .catch(error => {
-                    warn('failed to get page: ' + error);
-                    next()
-                });
+                    .then((data) => {
+                        if (data.status != 200 && data.status != 0) {
+                        }
+                        else {
+                            return data.text()
+                        }
+                    })
+                    .then((partial) => {
+                        processPartial(element, partial)
+                    })
+                    .catch(error => {
+                        warn('failed to get page: ' + error);
+                        next()
+                    });
             });
-          
+
         })
         return chain
     }
 
     //This function retries to load scripts that failed to load
     //and loads them into the container
-    retries( ){
+    retries() {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{    
+        let chain = new Promise((resolve, reject) => {
             let retryAgain = []
 
             let scriptCount = 0;
@@ -269,53 +267,52 @@ export class Tmplits {
             function next() {
                 scriptCount++
                 if (numberScript <= scriptCount) {
-                    if( retryAgain.length > 0 && retryAgain.length < numberScript )
-                    {
-                        setTimeout( ()=>{
+                    if (retryAgain.length > 0 && retryAgain.length < numberScript) {
+                        setTimeout(() => {
                             this.retryScripts = retryAgain
                             this.retries()
                         }, 0)
                     }
-                    else{
-                        retryAgain.forEach((el)=>{
+                    else {
+                        retryAgain.forEach((el) => {
                             const encodedJs = encodeURIComponent(el.innerHTML);
                             const dataUri = 'data:text/javascript;charset=utf-8,' + encodedJs;
                             log(`failing: ${el.id}`);
                             import(dataUri).then(ns => {
                                 Object.assign(window, ns);
                             })
-                        })            
+                        })
                         resolve()
                     }
                 }
             }
 
-            if( this.retryScripts.length > 0 ){
-                log('retrying to load scripts' )
-                this.retryScripts.forEach((el)=>{
-                    try{
+            if (this.retryScripts.length > 0) {
+                log('retrying to load scripts')
+                this.retryScripts.forEach((el) => {
+                    try {
                         const encodedJs = encodeURIComponent(el.innerHTML);
                         const dataUri = 'data:text/javascript;charset=utf-8,' + encodedJs;
                         log(`retrying: ${el.id}`);
                         import(dataUri).then(ns => {
                             Object.assign(window, ns);
                         })
-                        .then(()=>{
-                            next()                    
-                        })
-                        .catch((error)=>{
-                            warn('failed to parse script, will retry: ' + error);
-                            retryAgain.push(el)                        
-                            next()                    
-                        })
+                            .then(() => {
+                                next()
+                            })
+                            .catch((error) => {
+                                warn('failed to parse script, will retry: ' + error);
+                                retryAgain.push(el)
+                                next()
+                            })
                     }
-                    catch(e){
-                        retryAgain.push(el)                        
-                        next()                    
-                    }                  
-                })     
+                    catch (e) {
+                        retryAgain.push(el)
+                        next()
+                    }
+                })
             }
-            else{
+            else {
                 next()
             }
         })
@@ -329,24 +326,24 @@ export class Tmplits {
     //context is the context to load the page with
     loadPage(containerId, pageName, context) {
         var template = this.get(pageName);
-        context = context ? context : {}                    
+        context = context ? context : {}
         log(`Loading page: ${pageName}`)
         let dom = containerId
-        try{
-            if( typeof containerId == 'string'){
-                dom = '#' + containerId;    
+        try {
+            if (typeof containerId == 'string') {
+                dom = '#' + containerId;
             }
             $(dom).html(template(context))
         }
-        catch(e){
-            $(dom).html(`<div class="error">Error loading the page '${pageName}' ${e} </div>` )
+        catch (e) {
+            $(dom).html(`<div class="error">Error loading the page '${pageName}' ${e} </div>`)
         }
-        if( typeof WEBHMI !== 'undefined'){
+        if (typeof WEBHMI !== 'undefined') {
             try {
                 WEBHMI.queryDom()
-                WEBHMI.updateHMI()                        
+                WEBHMI.updateHMI()
             } catch (error) {
-                
+
             }
         }
     }
@@ -357,17 +354,17 @@ export class Tmplits {
         log(`Pushing template: ${template}`)
         var template = this.get(template);
         context = context ? context : window
-        try{
+        try {
             $(container).html(template(context))
         }
-        catch(e){
+        catch (e) {
             $(container).html(`<div class="error">Error loading the template '${template}' ${e} </div>`)
         }
-        if( typeof WEBHMI !== 'undefined'){
+        if (typeof WEBHMI !== 'undefined') {
             try {
                 WEBHMI.queryDom()
-                WEBHMI.updateHMI()                        
-            }catch{}
+                WEBHMI.updateHMI()
+            } catch { }
         }
     }
 
@@ -377,9 +374,9 @@ export class Tmplits {
         if (this.compiled[partial]) {
             return this.compiled[partial];
         }
-        if( typeof this.cache[partial] == "undefined"){
+        if (typeof this.cache[partial] == "undefined") {
             warn('could not find partial ' + partial)
-            return Handlebars.compile(`<div class="error">${partial} not found</div>`) 
+            return Handlebars.compile(`<div class="error">${partial} not found</div>`)
         }
         // ,{compat:true}
         this.compiled[partial] = Handlebars.compile(this.cache[partial]);
@@ -388,44 +385,44 @@ export class Tmplits {
     }
 
     //This function adds dom listeners to the page
-    addDomListeners( fileName ) {
+    addDomListeners(fileName) {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{    
+        let chain = new Promise((resolve, reject) => {
             $(document).on('DOMNodeInserted', function (e) {
                 $('[dynamic-template]').not("[dom-added=true]").each((i, el) => {
                     scope.refreshDynamicEl(el)
                 })
             })
             resolve();
-        })           
+        })
         return chain
     }
 
 
     //This function loads a json file defined by the user
     //and loads them into pages and libraries
-    loadJson( fileName ) {
+    loadJson(fileName) {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{    
+        let chain = new Promise((resolve, reject) => {
             log('loading ' + fileName)
             $.get(fileName, function (raw) {
 
-                if(typeof raw == 'string'){
+                if (typeof raw == 'string') {
                     raw = JSON.parse(raw)
                 }
 
                 scope.native = raw
-                Tmplits.debug =Object.assign( {} ,Tmplits.debug, raw.debug)
+                Tmplits.debug = Object.assign({}, Tmplits.debug, raw.debug)
                 //Append the package pages to the pages
                 scope.pages = scope.pages ? scope.pages : [];
-                raw.pages.forEach((e)=>{
+                raw.pages.forEach((e) => {
                     e.file = scope.base + e.file
                     e.source = fileName
                     scope.pages[e.name] = e
                 })
 
                 scope.libraries = scope.libraries ? scope.libraries : [];
-                raw.libraries.forEach((e)=>{
+                raw.libraries.forEach((e) => {
                     let lib = {};
                     lib.file = scope.base + e
                     lib.source = fileName
@@ -433,7 +430,7 @@ export class Tmplits {
                     scope.libraries.push(lib)
                 })
                 resolve();
-            }).fail(()=>{
+            }).fail(() => {
                 warn(fileName + ' not found, may not load all tmplits')
                 resolve();
             });
@@ -445,13 +442,13 @@ export class Tmplits {
     //This function loads a package json and finds the packages installed in 
     //@loupeteam/tmplits/ and loads them into pages
     //Then it searches for loader.js and runs it for each package
-    loadPackageJson( name ){
+    loadPackageJson(name) {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{
-            $.get( name, function (raw) {
+        let chain = new Promise((resolve, reject) => {
+            $.get(name, function (raw) {
                 log('loading ' + name)
 
-                if(typeof raw == 'string'){
+                if (typeof raw == 'string') {
                     raw = JSON.parse(raw)
                 }
 
@@ -461,40 +458,40 @@ export class Tmplits {
                 //and adding the package to the libraries and pages
                 scope.pages = scope.pages ? scope.pages : [];
                 scope.loaderScripts = scope.loaderScripts ? scope.loaderScripts : [];
-                for( let dep in raw.dependencies ){
-                    if( dep.startsWith('@loupeteam/tmplits-') ){
+                for (let dep in raw.dependencies) {
+                    if (dep.startsWith('@loupeteam/tmplits-')) {
                         //Add the package to the pages where the name is the package name without the @loupeteam/tmplits/
                         //and the file is the library.handlebars
                         let name = dep.replace('@loupeteam/tmplits-', '');
                         scope.pages[name] = {
-                            name: dep.replace('@loupeteam/tmplits-', ''), 
-                            file:  scope.base + dep + '/library.handlebars',
+                            name: dep.replace('@loupeteam/tmplits-', ''),
+                            file: scope.base + dep + '/library.handlebars',
                             script: scope.base + dep + '/loader.js',
                             module: scope.base + dep + '/module.js',
                             source: name
-                        } 
+                        }
                     }
-                    
-                }    
+
+                }
                 resolve();
-            }).fail(()=>{
+            }).fail(() => {
                 warn('package.json not found, may not load all tmplits')
                 resolve();
-            });      
+            });
         })
         return chain
     }
-    
+
     //This function loads a package-lock json and finds the packages installed in 
     //@loupeteam/tmplits/ and loads them into pages
     //Then it searches for loader.js and runs it for each package
-    loadPackageLockJson(name){
+    loadPackageLockJson(name) {
         let scope = this
-        let chain = new Promise((resolve, reject)=>{
+        let chain = new Promise((resolve, reject) => {
             log('loading ' + name)
             $.get(name, function (raw) {
 
-                if(typeof raw == 'string'){
+                if (typeof raw == 'string') {
                     raw = JSON.parse(raw)
                 }
 
@@ -504,91 +501,91 @@ export class Tmplits {
                 //and adding the package to the libraries and pages
                 scope.pages = scope.pages ? scope.pages : [];
                 scope.loaderScripts = scope.loaderScripts ? scope.loaderScripts : [];
-                for( let dep in raw.packages ){
-                    if( dep.startsWith('node_modules/@loupeteam/tmplits-') ){
+                for (let dep in raw.packages) {
+                    if (dep.startsWith('node_modules/@loupeteam/tmplits-')) {
                         //Add the package to the pages where the name is the package name without the @loupeteam/tmplits/
                         //and the file is the library.handlebars
-                        if( dep.replace('node_modules/@loupeteam/tmplits-', '').indexOf('/') == -1 ){                        
+                        if (dep.replace('node_modules/@loupeteam/tmplits-', '').indexOf('/') == -1) {
                             let name = dep.replace('node_modules/@loupeteam/tmplits-', '');
                             let path = dep.replace('node_modules/', '');
                             scope.pages[name] = {
-                                name: dep.replace('node_modules/@loupeteam/tmplits-', ''), 
-                                file:  scope.base + path + '/library.handlebars',
+                                name: dep.replace('node_modules/@loupeteam/tmplits-', ''),
+                                file: scope.base + path + '/library.handlebars',
                                 script: scope.base + path + '/loader.js',
                                 module: scope.base + path + '/module.js',
                                 source: name
-                            } 
+                            }
                         }
                     }
-                }    
+                }
                 resolve();
-            }).fail(()=>{
+            }).fail(() => {
                 warn('package-lock.json not found, may not load all dependent tmplits')
                 resolve()
-            });                 
+            });
         })
         return chain
     }
 
     //This function will create a module script to load a module then export all the exports to the window
-    loadModule( name ){
+    loadModule(name) {
         let scope = this
 
         Tmplits.modules[name] = true
 
         //Just fetch the head to check because the script will need to reload the module anyway
-        fetch(name,{ method: "HEAD" })
-        .then((res) => {
-            if (res.status == 200 || res.status == 0) {
-                let script = "" 
-//                    script += `console.log("Loading Module ${name}") ;`
-                script += `import * as module from '${name}';`
-                script += `Object.assign(window, module);`
-                script += `Object.assign(window, module);`
-                script += `Tmplits.moduleLoaded('${name}')`
-                scope.moduleEval(script)        
-            }
-            else{
-                Tmplits.moduleLoaded(name)
-            } 
-        })
+        fetch(name, { method: "HEAD" })
+            .then((res) => {
+                if (res.status == 200 || res.status == 0) {
+                    let script = ""
+                    //                    script += `console.log("Loading Module ${name}") ;`
+                    script += `import * as module from '${name}';`
+                    script += `Object.assign(window, module);`
+                    script += `Object.assign(window, module);`
+                    script += `Tmplits.moduleLoaded('${name}')`
+                    scope.moduleEval(script)
+                }
+                else {
+                    Tmplits.moduleLoaded(name)
+                }
+            })
     }
 
     //Mark module as loaded and if all the modules are loaded, load the pages
-    static moduleLoaded( name ){
+    static moduleLoaded(name) {
         this.modules[name] = false
         let allLoaded = true
-        for( let module in this.modules ){
-            if( this.modules[module] ){
+        for (let module in this.modules) {
+            if (this.modules[module]) {
                 allLoaded = false
             }
         }
-        if( allLoaded ){
+        if (allLoaded) {
             Tmplits.loadedCallback.forEach(callback => {
-                try{
+                try {
                     callback()
                 }
-                catch(e){
+                catch (e) {
                     warn('Error in loadedCallback: ' + e)
                 }
             });
-        }        
+        }
     }
     //This function loads a module script into the window
-	moduleEval( code ) {
+    moduleEval(code) {
         var doc = document
-		var i, val,
-			script = doc.createElement( "script" );
+        var i, val,
+            script = doc.createElement("script");
 
-		script.text = code;
-        script.setAttribute( 'type', "module" );
+        script.text = code;
+        script.setAttribute('type', "module");
 
-		doc.head.appendChild( script ).parentNode.removeChild( script );
-	}    
+        doc.head.appendChild(script).parentNode.removeChild(script);
+    }
 }
 
 export class viewDelegate {
-    constructor() {}
+    constructor() { }
     //     static observer = new MutationObserver(function (mutations) {
     // 		// Was a new webhmi element added to the DOM?
     // 		// Use Array.some() instead of Array.forEach() for easy loop break when we find a webhmi element added or remove from DOM
@@ -669,12 +666,12 @@ export class viewDelegate {
                 el.forEach((el) => {
                     let fn = e.fn()
                     el.innerHTML = fn
-                    if( typeof WEBHMI !== 'undefined'){
-                        try{
+                    if (typeof WEBHMI !== 'undefined') {
+                        try {
                             WEBHMI.queryDom()
-                            WEBHMI.updateHMI()    
+                            WEBHMI.updateHMI()
                         }
-                        catch{}
+                        catch { }
                     }
                 })
                 keep.push(e)
@@ -734,100 +731,99 @@ function delegatePartial(context, options, delegate, id, script) {
 
 function createTmplit(tmplit, ...args) {
 
-    let options = Object.assign( {}, args[args.length-1])
+    let options = Object.assign({}, args[args.length - 1])
     options.name = tmplit
-    let context = args.slice(0,-1)
-    options.hash = Object.assign( {}, options.hash, options.data.copy )
-    try{
-        var fn = eval('Tmplit'+tmplit)
+    let context = args.slice(0, -1)
+    options.hash = Object.assign({}, options.hash, options.data.copy)
+    try {
+        var fn = eval('Tmplit' + tmplit)
     }
-    catch(e){
-        try{
+    catch (e) {
+        try {
             fn = eval(tmplit)
             //If function is not undefined, then it is a tmplit
-            if( typeof fn !== 'undefined' ){
+            if (typeof fn !== 'undefined') {
                 console.warn('Tmplits names should prepend "Tmplit" to their name for clarity');
             }
         }
-        catch{
+        catch {
             var error = `<div class='error'>could not find Tmplit${tmplit}()</div>`
         }
     }
 
-    if( typeof fn != 'function'){
+    if (typeof fn != 'function') {
         var error = `<div class='error'>could not find Tmplit${tmplit}()</div>`
-        fn = ()=>{ return error}
+        fn = () => { return error }
     }
-    if( options.fn )
-    {
+    if (options.fn) {
         options.children = options.fn(options.hash)
-        if(error){
+        if (error) {
             return `<div class='error'>${error}${options.children}</div>`
         }
-        else{
-            if(Tmplits.debug.comment){
-                return `<!--⌄{w ${tmplit}}-->${fn( context, options )}<!--^{w ${tmplit}}-->`
+        else {
+            if (Tmplits.debug.comment) {
+                return `<!--⌄{w ${tmplit}}-->${fn(context, options)}<!--^{w ${tmplit}}-->`
             }
-            else{
-                return fn( context, options )
+            else {
+                return fn(context, options)
             }
         }
     }
-    else{
-        if(error){
+    else {
+        if (error) {
             return {
-                toHTML(){
+                toHTML() {
                     return error
                 }
-            }    
-        }        
-        else{
+            }
+        }
+        else {
             return {
-                toHTML(){
+                toHTML() {
                     options.children = ''
-                    if(Tmplits.debug.comment){
-                        return `<!--⌄{w ${tmplit}}-->${fn( context, options )}<!--^{w ${tmplit}}-->`
+                    if (Tmplits.debug.comment) {
+                        return `<!--⌄{w ${tmplit}}-->${fn(context, options)}<!--^{w ${tmplit}}-->`
                     }
-                    else{
-                        return fn( context, options )
+                    else {
+                        return fn(context, options)
                     }
                 }
-            }    
+            }
         }
     }
 }
 
 function createObject(json, options) {
 
-    let obj; 
+    let obj;
 
-    try{
+    try {
         obj = JSON.parse(json);
     }
-    catch(e){
-        try{
-            obj =  eval(`( ${json} )`)
+    catch (e) {
+        try {
+            obj = eval(`( ${json} )`)
         }
-        catch(e){
+        catch (e) {
             obj = e
         }
     }
-    if(options.fn){
+    if (options.fn) {
         return options.fn(obj)
-    }    
-    else{
+    }
+    else {
         return obj
     }
 }
 
-function copyContext(context, ...args) {    
+function copyContext(context, ...args) {
     let _utils = Handlebars.Utils;
     //Get the context and options from the arguments    
     let options = args[args.length - 1]
 
     //Combine the context with the hash, this is the main copy operation
     let contextArray = Object.assign({}, context, args.slice(0, -1), options.hash)
-    
+
     //Create a copy of the context without the hash
     //  Remove any items that were blacklisted
     //  These are things that should not be added as attributes
@@ -843,9 +839,9 @@ function copyContext(context, ...args) {
 
     //Copy to the copyArrayClean to avoid class being removed by the cleanArgs function
     let copyArrayClean = Object.assign({}, copyArray)
-    let {attr, classList} = cleanArgs(copyArrayClean)
+    let { attr, classList } = cleanArgs(copyArrayClean)
 
-    if(classList.length > 0){
+    if (classList.length > 0) {
         attr += ' class="' + classList.join(' ') + "\""
     }
     //Add the classlist to the context
@@ -858,9 +854,9 @@ function copyContext(context, ...args) {
         //  Copy is to support tmplits copying to the hash
         //  Attr is to support partials, which don't have a hash
         //  ToHTML is to support partials, because otherwise it will get escaped
-        data = Object.assign(data, { copy: copyArray, attr: {toHTML(){ return attr } } })
+        data = Object.assign(data, { copy: copyArray, attr: { toHTML() { return attr } } })
     }
-    
+
     //Call the child with the parent context
     options.children = options.fn(contextArray, { data: data })
     return options.children
@@ -869,16 +865,16 @@ function copyContext(context, ...args) {
 Handlebars.registerHelper('Partial', function (context, ...args) {
 
     //Get the context and options from the arguments
-    let options = args[args.length-1]
-    let contextArray = args.slice(0,-1)
-    contextArray = Object.assign( {}, contextArray, options.hash )
+    let options = args[args.length - 1]
+    let contextArray = args.slice(0, -1)
+    contextArray = Object.assign({}, contextArray, options.hash)
     //Get the tmplit name from the first option
     let tmplit = tmplits.get(context)
-    if( typeof tmplit == 'undefined' ){
-        try{
-            tmplit =  Handlebars.compile(context);                
+    if (typeof tmplit == 'undefined') {
+        try {
+            tmplit = Handlebars.compile(context);
         }
-        catch(e){
+        catch (e) {
             tmplit = Handlebars.compile(`<div class='error'>${e}</div>`)
         }
     }
@@ -1053,12 +1049,12 @@ Handlebars.registerHelper('repeat', function (context, options) {
     return ret;
 });
 
-Handlebars.registerHelper('concat', function (...args){
+Handlebars.registerHelper('concat', function (...args) {
 
     // let options = Object.assign( {}, args[args.length-1])
-    let context = args.slice(0,-1)
+    let context = args.slice(0, -1)
     let ret = ''
-    context.forEach(e=>{
+    context.forEach(e => {
         ret += e;
     })
     return ret
@@ -1078,17 +1074,17 @@ Handlebars.registerHelper("math", function (lvalue, operator, rvalue) {
         "*": lvalue * rvalue,
         "/": lvalue / rvalue,
         "%": lvalue % rvalue
-    } [operator];
+    }[operator];
 });
 
 //This function is an if for two arguments equal
-Handlebars.registerHelper('ifEquals', function(arg1, arg2, options) {
+Handlebars.registerHelper('ifEquals', function (arg1, arg2, options) {
     return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
 });
 
 //Go through the context and find the variable path
-Handlebars.registerHelper('VariablePath', function(context, args) {
-    return util.getVariablePath( context.data, '' );
+Handlebars.registerHelper('VariablePath', function (context, args) {
+    return util.getVariablePath(context.data, '');
 });
 
 window.Tmplits = Tmplits


### PR DESCRIPTION
# What

Fix jQuery conflict

# Why

Loading jQuery multiple times can cause inconsistencies in which jQuery objects libraries use. Tmplits loads jQuery unconditionally because that is a condition of the standard ES6 import, then checks if it should have and saves it to the window if it didn't already exist. This requires calling no conflict if it should not have loaded it.

We could have implemented the function based import conditionally, but we could still have problems if others load jQuery later, and it would complicate the logic to load pages, since we would need to wait for the import. This solves the problem in a less efficient way, since we are always loading jQuery, but it simplifies some other problems.
