### PR TITLE
Fix jQuery Conflict main

### DIFF
--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -11,14 +11,20 @@ import "../../jquery/dist/jquery.js"
 import * as util from "../tmplits-utilities/module.js"
 
 //Check if jquery has already been loaded
-//If it hasn't then load it
-if( !window.$ ){
-    window.$ = jQuery
+//If it hasn't then save it to the window for others to use
+if (!window.$) {
+    window.$ = jQueryImport
     console.error('Loading JQuery in tmplits.js. To avoid this ensure that JQuery is loaded before tmplits.js')
 }
-let log = function( t ){ if(Tmplits.debug.loglevel == 0){ console.log(t) }};
-let warn = function( t ){ if(Tmplits.debug.loglevel <= 1){ console.warn(t) }};
-let error = function( t ){ if(Tmplits.debug.loglevel <= 2){ console.error(t) }};
+else {
+    //Use deep no conflict to avoid conflicts with other loading JQuery.
+    // We actually don't care what version of jquery, but we do care if it is loaded
+    // and import requires loading it unconditionally. So we load it here and then
+    // use noConflict to avoid conflicts with other versions of jquery
+    debugger
+    $.noConflict(true);
+}
+
 
 export class Tmplits {
     constructor(node_module_directory, loadedCallback ) {

--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -10,19 +10,17 @@
 import "../../jquery/dist/jquery.js"
 import * as util from "../tmplits-utilities/module.js"
 
-//Check if jquery has already been loaded
-//If it hasn't then save it to the window for others to use
-if (!window.$) {
-    window.$ = jQueryImport
-    console.error('Loading JQuery in tmplits.js. To avoid this ensure that JQuery is loaded before tmplits.js')
-}
-else {
-    //Use deep no conflict to avoid conflicts with other loading JQuery.
-    // We actually don't care what version of jquery, but we do care if it is loaded
-    // and import requires loading it unconditionally. So we load it here and then
-    // use noConflict to avoid conflicts with other versions of jquery
-    debugger
+//There is no way to load jquery as a module, so it will always be loaded as a global
+//If jquery was loaded it means that we are in a browser, or it was already loaded
+//  fall back to any previous version that was loaded. If we are the first version, that is fine too..
+if (window.$) {
     $.noConflict(true);
+}
+//If jquery was not loaded then we are in electron, lets require it
+else {
+    //We don't need no conflict because we already know that jquery is not loaded previously
+    let jqueryImport = require("jquery");
+    window.$ = window.jQuery = jqueryImport;
 }
 
 


### PR DESCRIPTION
# What

Fix jQuery conflict

# Why

Loading jQuery multiple times can cause inconsistencies in which jQuery objects libraries use. Tmplits loads jQuery unconditionally because that is a condition of the standard ES6 import, then checks if it should have and saves it to the window if it didn't already exist. This requires calling no conflict if it should not have loaded it.

We could have implemented the function based import conditionally, but we could still have problems if others load jQuery later, and it would complicate the logic to load pages, since we would need to wait for the import. This solves the problem in a less efficient way, since we are always loading jQuery, but it simplifies some other problems.