### PR TITLE
Prelux/package lock

### DIFF
--- a/example/HMI/package-lock.json
+++ b/example/HMI/package-lock.json
@@ -39,6 +39,7 @@
       }
     },
     "../../src/HMI": {
+      "name": "@loupeteam/tmplits",
       "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
@@ -47,6 +48,7 @@
       }
     },
     "../../src/tmplits/tmplits-button": {
+      "name": "@loupeteam/tmplits-button",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -55,6 +57,7 @@
       }
     },
     "../../src/tmplits/tmplits-checkbox": {
+      "name": "@loupeteam/tmplits-checkbox",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -63,6 +66,7 @@
       }
     },
     "../../src/tmplits/tmplits-columns": {
+      "name": "@loupeteam/tmplits-columns",
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
@@ -71,6 +75,7 @@
       }
     },
     "../../src/tmplits/tmplits-columnsbs": {
+      "name": "@loupeteam/tmplits-columnsbs",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -79,6 +84,7 @@
       }
     },
     "../../src/tmplits/tmplits-directorybrowser": {
+      "name": "@loupeteam/tmplits-directorybrowser",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -87,6 +93,7 @@
       }
     },
     "../../src/tmplits/tmplits-directorybrowserwindow": {
+      "name": "@loupeteam/tmplits-directorybrowserwindow",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -95,6 +102,7 @@
       }
     },
     "../../src/tmplits/tmplits-dropdown": {
+      "name": "@loupeteam/tmplits-dropdown",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -103,6 +111,7 @@
       }
     },
     "../../src/tmplits/tmplits-dropdowntable": {
+      "name": "@loupeteam/tmplits-dropdowntable",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -111,6 +120,7 @@
       }
     },
     "../../src/tmplits/tmplits-globalclasses": {
+      "name": "@loupeteam/tmplits-globalclasses",
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
@@ -118,6 +128,7 @@
       }
     },
     "../../src/tmplits/tmplits-labeledlist": {
+      "name": "@loupeteam/tmplits-labeledlist",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -126,6 +137,7 @@
       }
     },
     "../../src/tmplits/tmplits-led": {
+      "name": "@loupeteam/tmplits-led",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -134,6 +146,7 @@
       }
     },
     "../../src/tmplits/tmplits-multiselect": {
+      "name": "@loupeteam/tmplits-multiselect",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -142,6 +155,7 @@
       }
     },
     "../../src/tmplits/tmplits-numeric": {
+      "name": "@loupeteam/tmplits-numeric",
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
@@ -150,6 +164,7 @@
       }
     },
     "../../src/tmplits/tmplits-numgrid": {
+      "name": "@loupeteam/tmplits-numgrid",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -158,6 +173,7 @@
       }
     },
     "../../src/tmplits/tmplits-page": {
+      "name": "@loupeteam/tmplits-page",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -166,6 +182,7 @@
       }
     },
     "../../src/tmplits/tmplits-pageselect": {
+      "name": "@loupeteam/tmplits-pageselect",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -174,6 +191,7 @@
       }
     },
     "../../src/tmplits/tmplits-slider": {
+      "name": "@loupeteam/tmplits-slider",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -182,6 +200,7 @@
       }
     },
     "../../src/tmplits/tmplits-tableselect": {
+      "name": "@loupeteam/tmplits-tableselect",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -190,6 +209,7 @@
       }
     },
     "../../src/tmplits/tmplits-text": {
+      "name": "@loupeteam/tmplits-text",
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
@@ -198,10 +218,12 @@
       }
     },
     "../../src/tmplits/tmplits-utilities": {
+      "name": "@loupeteam/tmplits-utilities",
       "version": "0.0.4",
       "license": "MIT"
     },
     "../../src/tmplits/tmplits-valueupdown": {
+      "name": "@loupeteam/tmplits-valueupdown",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {

--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits",
-  "version": "0.0.13-rc",
+  "version": "0.0.13-rc1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits",
-  "version": "0.0.13-rc1",
+  "version": "0.0.13",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/tmplits",
-  "version": "0.0.12",
+  "version": "0.0.13-rc",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/HMI/tmplits.js
+++ b/src/HMI/tmplits.js
@@ -44,7 +44,8 @@ export class Tmplits {
             Tmplits.loadedCallback.push(() => { loadedCallback(this.native) })
         }
         Tmplits.loadedCallback.push(() => { this.refreshDynamicDom() })
-        this.loadPackageLockJson(this.base + '../package-lock.json')
+        this.loadPackageLockJson(this.base + './.package-lock.json')
+            .then(() => { return this.loadPackageLockJson(this.base + '../package.json') })
             .then(() => { return this.loadPackageJson(this.base + '../package.json') })
             .then(() => { return this.loadJson(this.base + '../tmplits.json') })
             .then(() => { return this.getLibraries(this.libraries) })


### PR DESCRIPTION
# What

Read the node_modules/.pack-lock.json

# Why

We currently read the package-lock.json to get a list of ALL the tmplits that have been installed, directly and indirectly (because it's a dependency). Electron forge does not include the package-lock.json, but it DOES include the .package-lock.json in the node_modules folder. 

This PR adds reading BOTH, just in case. One may throw an error if it doesn't exist, but that's OK.