### PR TITLE
HMILayout via slotchange

### DIFF
--- a/example/HMI/app/views/main.handlebars
+++ b/example/HMI/app/views/main.handlebars
@@ -1,23 +1,22 @@
 <lui-basic-layout navBar="left">
-<div id="contentArea">
-    <template title="Button 1">
+    
+    <div slot="list" title="Button 1">
         {{>OpenBridge }}
-        {{!-- <h1>Content  1</h1> --}}
-    </template>
-    
-    <template title="Button 2">
-        {{>testComponents }}
-        {{!-- <h1>Content  2</h1> --}}
-    </template>   
+        {{!-- <h1>Content 1</h1> --}}
+    </div>
 
-    <template title="Button 3">
+    <div slot="list" title="Button 2">
+        {{>testComponents }}
+        {{!-- <h1>Content 2</h1> --}}
+    </div>
+
+    <div slot="list" title="Button 3">
         {{>nav}}
-        {{!-- <h1>Cosntent  3</h1> --}}
-    </template>
-</div>
-    
-<div slot="footer">
-    Copyright        
-</div>
+        {{!-- <h1>Cosntent 3</h1> --}}
+    </div>
+
+    <footer slot="footer">
+        Copyright
+    </footer>
 
 </lui-basic-layout>

--- a/src/tmplits/tmplits-hmilayout/module.js
+++ b/src/tmplits/tmplits-hmilayout/module.js
@@ -2,8 +2,8 @@ import * as util from "../tmplits-utilities/module.js"
 
 //Style Template
 const styleTemplate = document.createElement('template');
-styleTemplate.innerHTML = 
-`
+styleTemplate.innerHTML =
+    `
 <style>
 /* Parent grid */
 .tmplit-layout-grid{
@@ -117,9 +117,9 @@ class basicLayout extends HTMLElement {
 
     noChange = false;
     constructor() {
-        super() 
-        //Find the template tags and move them to the shadow dom
-        let nodes = this.querySelectorAll('template')
+        super()
+        //Find the div list tags
+        let nodes = this.querySelectorAll('div[slot=list]')
         let labels = []
 
         for (let i in nodes) {
@@ -127,7 +127,7 @@ class basicLayout extends HTMLElement {
             switch (el.tagName) {
                 case undefined:
                     break;
-                case 'TEMPLATE':
+                case 'DIV':
                     labels.push(el.getAttribute("title"))
                     break;
                 default:
@@ -167,19 +167,20 @@ class basicLayout extends HTMLElement {
         this.shadowRoot.appendChild(styleTemplate.content.cloneNode(true));
         this.shadowRoot.innerHTML += this.innerHTML;
         let navbar = this.shadowRoot.querySelector(".tmplit-navBar-container");
-        for(let i in labels){
+        for (let i in labels) {
             let button = document.createElement(`div`);
             button.classList.add('tmplit-navBar-button')
             button.innerHTML = labels[i] ? labels[i] : +i + 1;
-            button.addEventListener('click', ()=>{this.setAttribute('value',i)})
-            navbar.appendChild( button )
+            button.addEventListener('click', () => { this.setAttribute('value', i) })
+            navbar.appendChild(button)
         }
-        if(!this.hasAttribute('value')){           
+        if (!this.hasAttribute('value')) {
             this.setAttribute('value', 0)
             this.selectPage(this.getAttribute('value'))
         }
+
     }
-    
+
     //Tell the DOM to observe 'value' attribute for changes
     static get observedAttributes() {
         return ['value']
@@ -191,11 +192,11 @@ class basicLayout extends HTMLElement {
             case 'value':
                 this.selectPage(newValue)
                 //Raise an event
-                if(!this.noChange){
+                if (!this.noChange) {
                     this.dispatchEvent(new Event("change", {
                         "bubbles": true,
                         "cancelable": true
-                    }));    
+                    }));
                 }
                 break;
             default:
@@ -203,26 +204,25 @@ class basicLayout extends HTMLElement {
         }
     }
 
-    selectPage(templatesIndex){
-        let templates = this.shadowRoot.querySelectorAll('template')
-        let content = this.shadowRoot.querySelector('slot:not([name])')
-        // let footer = this.querySelector('[slot="footer"]')
-        
-        if(+templatesIndex < templates.length){            
-            let contentArea = this.querySelector('#contentArea')
-            contentArea.innerHTML = templates[templatesIndex].innerHTML
-            // content.innerHTML = templates[templatesIndex].innerHTML
-            // this.innerHTML = content.innerHTML
-            // this.append(footer)
+    selectPage(templatesIndex) {
+        let divs = this.querySelectorAll('div[slot]')
+        divs.forEach(div => {
+            // set every other slot div back to list slot
+            div.setAttribute('slot', 'list')
+            // TODO could do this more elegantly
+        });
+
+        if (+templatesIndex < divs.length) {
+            divs[templatesIndex].setAttribute('slot', 'content')
         }
-        else{
-            this.innerHTML = "Not Found"         
+        else {
+            this.innerHTML = "Not Found"
         }
     }
-    get value(){
+    get value() {
         return this.getAttribute('value');
     }
-    set value(val){
+    set value(val) {
         this.noChange = true;
         this.setAttribute('value', val)
         this.noChange = false;

--- a/src/tmplits/tmplits-hmilayout/module.js
+++ b/src/tmplits/tmplits-hmilayout/module.js
@@ -136,23 +136,23 @@ class basicLayout extends HTMLElement {
         }
 
         let navBarLoc = this.getAttribute('navBar')
-        this.attachShadow({mode: 'open'})
+        this.attachShadow({ mode: 'open' })
         this.shadowRoot.innerHTML = `
         <div class="tmplit-layout-grid">
             <div class="tmplit-main-container
-                        ${navBarLoc ==='left' || navBarLoc ==='right' ? 'tmplit-main-container-left-right' : 
-                        navBarLoc ==='top' || navBarLoc ==='bottom' ? 'tmplit-main-container-top-bottom' :'mplit-main-container-left-right'}">
+                        ${navBarLoc === 'left' || navBarLoc === 'right' ? 'tmplit-main-container-left-right' :
+                navBarLoc === 'top' || navBarLoc === 'bottom' ? 'tmplit-main-container-top-bottom' : 'mplit-main-container-left-right'}">
                 <div class="tmplit-navBar-container
-                            ${navBarLoc ==='left' ? 'tmplit-navBar-container-left tmplit-navBar-container-width-size' :
-                            navBarLoc ==='right' ? 'tmplit-navBar-container-right tmplit-navBar-container-width-size' :
-                            navBarLoc ==='top' ? 'tmplit-navBar-container-top tmplit-navBar-container-height-size' :
-                            navBarLoc ==='bottom' ? 'tmplit-navBar-container-bottom tmplit-navBar-container-height-size' : 
+                            ${navBarLoc === 'left' ? 'tmplit-navBar-container-left tmplit-navBar-container-width-size' :
+                navBarLoc === 'right' ? 'tmplit-navBar-container-right tmplit-navBar-container-width-size' :
+                    navBarLoc === 'top' ? 'tmplit-navBar-container-top tmplit-navBar-container-height-size' :
+                        navBarLoc === 'bottom' ? 'tmplit-navBar-container-bottom tmplit-navBar-container-height-size' :
                             'tmplit-navBar-container-left tmplit-navBar-container-width-size'}">
                 </div>
 
                 <div class="tmplit-main-content">
-                    <slot>
-                        DEFAULT SLOT
+                    <slot name="content">
+                        DEFAULT CONTENT
                     </slot>
                 </div>             
             </div>


### PR DESCRIPTION
# What

This a proof of concept / alternative strategy for Sanh's project, for learning and discussion purposes.

This demo shows how to change which content goes into a slot dynamically, by changing the slot attribute's value on various content fed into the component.

Content is put into the component, representing tabbed content. These divs are marked with the attribute/value `slot="list"`. Selecting on this yields a list of pages to make navigation for.

The component's template has a content slot set aside for the active page ( `slot="content"` ). When the buttons for various pages are selected, that then reassigns the slot attributes for the tabbed areas.

This concept is based on MDN Web Components example "slotchange" https://github.com/mdn/web-components-examples/blob/main/slotchange/main.js

# Why

Exploring other ways to "swap" what content goes into a given slot.